### PR TITLE
Render multiple images (bug)

### DIFF
--- a/test/multiImage.spec.js
+++ b/test/multiImage.spec.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import { PIXI, Canvas } from '../src/index';
+
+describe('multiImage', function() {
+    this.timeout(5000);
+
+    it('should render multiple images', cb => {
+        const app = new PIXI.Application({
+          backgroundColor: 0xff0000,
+          forceCanvas: false,
+        });
+
+        PIXI.loader
+          .add(
+            'img_0',
+            'https://www.famousbirthdays.com/headshots/che-guevara-1.jpg',
+          )
+          .add(
+            'img_1',
+            'https://www.famousbirthdays.com/faces/obama-barack-image.jpg',
+          );
+
+        PIXI.loader.onComplete.add(() => {
+          let img_0 = new PIXI.Sprite(PIXI.loader.resources.img_0.texture);
+          let img_1 = new PIXI.Sprite(PIXI.loader.resources.img_1.texture);
+
+          // Setup the position of img_0
+          img_0.x = 0;
+          img_0.y = 0;
+
+          img_1.x = 300;
+          img_1.y = 0;
+
+          app.stage.addChild(img_0);
+          app.stage.addChild(img_1);
+
+          app.render();
+
+          // toBuffer returns a Promise
+          app.view
+            .toBuffer('jpg', 1)
+            .then(buffer => {
+              fs.writeFileSync(
+                'people.jpg',
+                buffer,
+              );
+              process.exit(0);
+            })
+            .catch(err => {
+              console.error(err);
+              process.exit(0);
+            });
+        });
+
+        PIXI.loader.load();
+
+    });
+});


### PR DESCRIPTION
Firstly, great library :) I'm glad someone has finally started on node.js support. 

I'm seeing a bug when I try to render multiple images with WebGL. 

This is what I see right now:

![current](https://user-images.githubusercontent.com/151172/35482004-9f4b3e4a-0426-11e8-9cc8-caf802fb4842.jpg)

If I set `forceCanvas: true` and don't [convert the Image to ImageData](https://github.com/timknip/node-pixi/blob/master/src/index.js#L18-L19) it works as expected:

![expected](https://user-images.githubusercontent.com/151172/35482006-a4ba38f4-0426-11e8-865c-7167162a6425.jpg)

Any thoughts on what could be causing this?